### PR TITLE
Feat/add meru model

### DIFF
--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,6 +1,7 @@
 from .clip_models import CLIPModel
 from .imagenet_models import ImagenetModel
 from .dinov2_models import DinoModel
+from .meru_models import MeruModel
 
 
 VALID_NAMES = [
@@ -27,6 +28,7 @@ VALID_NAMES = [
     "CLIP:ViT-B/16",
     "CLIP:ViT-L/14",
     "CLIP:ViT-L/14@336px",
+    "Meru:Vit-S",
     "Dino:Vit-B/14",
 ]
 
@@ -39,5 +41,7 @@ def get_model(name):
         return CLIPModel(name[5:])
     elif name.startswith("Dino:"):
         return DinoModel(name[5:])
+    elif name.startswith("Meru:"):
+        return MeruModel(name[5:])
     else:
         assert False

--- a/models/meru/distributed.py
+++ b/models/meru/distributed.py
@@ -1,0 +1,169 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Collection of common utilities for distributed training. These are wrappers over
+functions from :mod:`torch.distributed` module, but they do not raise exceptions
+in absence of multi-GPU or CPU mode, and fall back to sensible default behavior.
+"""
+from __future__ import annotations
+
+from typing import Callable
+
+import torch
+
+# from loguru import logger
+from torch import distributed as dist
+from torch import multiprocessing as mp
+from torch.distributed.nn import all_gather as nn_all_gather
+
+
+def launch(
+    job_fn: Callable,
+    num_machines: int = 1,
+    num_gpus_per_machine: int = 1,
+    machine_rank: int = 0,
+    dist_url: str = "tcp://127.0.0.1:23457",
+    args=(),
+):
+    """
+    Launch a job in a distributed fashion: given `num_machines` machines, each
+    with `num_gpus_per_machine` GPUs, this function will launch one process per
+    GPU. This wrapper uses :func:`torch.multiprocessing.spawn`.
+
+    The user has to launch one job on each machine, manually specifying a machine
+    rank (incrementing integers from 0). This function will offset process ranks
+    per machine. One process on `machine_rank = 0` will be the *main process*,
+    and a free port on that machine will be used for process communication.
+
+    Default arguments imply one machine with one GPU, and communication URL
+    as `localhost`.
+
+    .. note::
+
+        We assume all machines have same number of GPUs per machine, with IDs as
+        `(0, 1, 2 ...)`. If you do not wish to use all GPUs on a machine,
+        set `CUDA_VISIBLE_DEVICES` environment variable appropriately.
+
+    Args:
+        job_fn: Function to launch -- this could be your model training function.
+        num_machines: Number of machines, each with `num_gpus_per_machine` GPUs.
+        num_gpus_per_machine: GPUs per machine, with IDs as `(0, 1, 2 ...)`.
+        machine_rank: A manually specified rank of the machine, serves as a
+            unique identifier and useful for assigning global ranks to processes.
+        dist_url: Disributed process communication URL as `tcp://x.x.x.x:port`.
+            Set this as the IP (and a free port) of machine with rank 0.
+        args: Arguments to be passed to `job_fn`.
+    """
+
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA not found! Cannot launch distributed processes.")
+
+    world_size = num_machines * num_gpus_per_machine
+
+    # Spawn `num_gpus_per_machine` processes per machine, and provide
+    # "local process rank" (GPU ID) as the first arg to `_dist_worker`.
+    # fmt: off
+    if world_size > 1:
+        mp.spawn(
+            _job_worker,
+            nprocs=num_gpus_per_machine,
+            args=(
+                job_fn, world_size, num_gpus_per_machine, machine_rank, dist_url, args
+            ),
+            daemon=False,
+        )
+    else:
+        # Default to single machine, single GPU, with ID 0.
+        _job_worker(0, job_fn, 1, 1, 0, dist_url, args)
+    # fmt: on
+
+
+def _job_worker(
+    local_rank: int,
+    job_fn: Callable,
+    world_size: int,
+    num_gpus_per_machine: int,
+    machine_rank: int,
+    dist_url: str,
+    args: tuple,
+):
+    """
+    Single distibuted process worker. This function should never be used directly,
+    only used by :func:`launch`.
+    """
+
+    # Adjust global rank of process based on its machine rank.
+    global_rank = machine_rank * num_gpus_per_machine + local_rank
+    try:
+        dist.init_process_group(
+            backend="NCCL",
+            init_method=dist_url,
+            world_size=world_size,
+            rank=global_rank,
+        )
+    except Exception as e:
+        # logger.error(f"Error launching processes, dist URL: {dist_url}")
+        raise e
+
+    synchronize()
+    # Set GPU ID for each process according to its rank.
+    torch.cuda.set_device(local_rank)
+    job_fn(*args)
+
+
+def synchronize() -> None:
+    """Synchronize (barrier) all processes in a process group."""
+    if dist.is_initialized():
+        dist.barrier()
+
+
+def get_world_size() -> int:
+    """Return number of processes in the process group, each uses 1 GPU."""
+    return dist.get_world_size() if dist.is_initialized() else 1
+
+
+def get_rank() -> int:
+    """Return rank of current process in the process group."""
+    return dist.get_rank() if dist.is_initialized() else 0
+
+
+def is_main_process() -> bool:
+    """
+    Check whether current process is the main process. This check is useful
+    to restrict logging and checkpointing to main process. It will always
+    return `True` for single machine, single GPU execution.
+    """
+    return get_rank() == 0
+
+
+def gather_across_processes(t: torch.Tensor) -> list[torch.Tensor]:
+    """
+    Gather tensors from multiple GPU processes in a list. The order of elements
+    is preserved by GPU process IDs. This operation is differentiable; gradients
+    will be scattered back to devices in the backward pass.
+
+    Args:
+        t: Tensor to gather across processes.
+    """
+    world_size = dist.get_world_size()
+    if world_size == 1:
+        return [t]
+
+    output = list(nn_all_gather(t))
+    return output
+
+
+def gpu_mem_usage() -> int:
+    """
+    Return gpu memory usage (in megabytes). If not using GPU, return 0 without
+    raising any exceptions.
+    """
+    if torch.cuda.is_available():
+        # This will be in bytes, so we divide by (1024 * 1024).
+        return torch.cuda.max_memory_allocated() // 1048576
+    else:
+        return 0

--- a/models/meru/lorentz.py
+++ b/models/meru/lorentz.py
@@ -1,0 +1,193 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Implementation of common operations for the Lorentz model of hyperbolic geometry.
+This model represents a hyperbolic space of `d` dimensions on the upper-half of
+a two-sheeted hyperboloid in a Euclidean space of `(d+1)` dimensions.
+
+Hyperbolic geometry has a direct connection to the study of special relativity
+theory -- implementations in this module borrow some of its terminology. The axis
+of symmetry of the Hyperboloid is called the _time dimension_, while all other
+axes are collectively called _space dimensions_.
+
+All functions implemented here only input/output the space components, while
+while calculating the time component according to the Hyperboloid constraint:
+
+    `x_time = torch.sqrt(1 / curv + torch.norm(x_space) ** 2)`
+"""
+from __future__ import annotations
+
+import math
+
+import torch
+from torch import Tensor
+
+
+def pairwise_inner(x: Tensor, y: Tensor, curv: float | Tensor = 1.0):
+    """
+    Compute pairwise Lorentzian inner product between input vectors.
+
+    Args:
+        x: Tensor of shape `(B1, D)` giving a space components of a batch
+            of vectors on the hyperboloid.
+        y: Tensor of shape `(B2, D)` giving a space components of another
+            batch of points on the hyperboloid.
+        curv: Positive scalar denoting negative hyperboloid curvature.
+        eps: Small float number to avoid numerical instability.
+
+    Returns:
+        Tensor of shape `(B1, B2)` giving pairwise Lorentzian inner product
+        between input vectors.
+    """
+
+    x_time = torch.sqrt(1 / curv + torch.sum(x**2, dim=-1, keepdim=True))
+    y_time = torch.sqrt(1 / curv + torch.sum(y**2, dim=-1, keepdim=True))
+    xyl = x @ y.T - x_time @ y_time.T
+    return xyl
+
+
+def pairwise_dist(
+    x: Tensor, y: Tensor, curv: float | Tensor = 1.0, eps: float = 1e-8
+) -> Tensor:
+    """
+    Compute the pairwise geodesic distance between two batches of points on
+    the hyperboloid.
+
+    Args:
+        x: Tensor of shape `(B1, D)` giving a space components of a batch
+            of point on the hyperboloid.
+        y: Tensor of shape `(B2, D)` giving a space components of another
+            batch of points on the hyperboloid.
+        curv: Positive scalar denoting negative hyperboloid curvature.
+        eps: Small float number to avoid numerical instability.
+
+    Returns:
+        Tensor of shape `(B1, B2)` giving pairwise distance along the geodesics
+        connecting the input points.
+    """
+
+    # Ensure numerical stability in arc-cosh by clamping input.
+    c_xyl = -curv * pairwise_inner(x, y, curv)
+    _distance = torch.acosh(torch.clamp(c_xyl, min=1 + eps))
+    return _distance / curv**0.5
+
+
+def exp_map0(x: Tensor, curv: float | Tensor = 1.0, eps: float = 1e-8) -> Tensor:
+    """
+    Map points from the tangent space at the vertex of hyperboloid, on to the
+    hyperboloid. This mapping is done using the exponential map of Lorentz model.
+
+    Args:
+        x: Tensor of shape `(B, D)` giving batch of Euclidean vectors to project
+            onto the hyperboloid. These vectors are interpreted as velocity
+            vectors in the tangent space at the hyperboloid vertex.
+        curv: Positive scalar denoting negative hyperboloid curvature.
+        eps: Small float number to avoid division by zero.
+
+    Returns:
+        Tensor of same shape as `x`, giving space components of the mapped
+        vectors on the hyperboloid.
+    """
+
+    rc_xnorm = curv**0.5 * torch.norm(x, dim=-1, keepdim=True)
+
+    # Ensure numerical stability in sinh by clamping input.
+    sinh_input = torch.clamp(rc_xnorm, min=eps, max=math.asinh(2**15))
+    _output = torch.sinh(sinh_input) * x / torch.clamp(rc_xnorm, min=eps)
+    return _output
+
+
+def log_map0(x: Tensor, curv: float | Tensor = 1.0, eps: float = 1e-8) -> Tensor:
+    """
+    Inverse of the exponential map: map points from the hyperboloid on to the
+    tangent space at the vertex, using the logarithmic map of Lorentz model.
+
+    Args:
+        x: Tensor of shape `(B, D)` giving space components of points
+            on the hyperboloid.
+        curv: Positive scalar denoting negative hyperboloid curvature.
+        eps: Small float number to avoid division by zero.
+
+    Returns:
+        Tensor of same shape as `x`, giving Euclidean vectors in the tangent
+        space of the hyperboloid vertex.
+    """
+
+    # Calculate distance of vectors to the hyperboloid vertex.
+    rc_x_time = torch.sqrt(1 + curv * torch.sum(x**2, dim=-1, keepdim=True))
+    _distance0 = torch.acosh(torch.clamp(rc_x_time, min=1 + eps))
+
+    rc_xnorm = curv**0.5 * torch.norm(x, dim=-1, keepdim=True)
+    _output = _distance0 * x / torch.clamp(rc_xnorm, min=eps)
+    return _output
+
+
+def half_aperture(
+    x: Tensor, curv: float | Tensor = 1.0, min_radius: float = 0.1, eps: float = 1e-8
+) -> Tensor:
+    """
+    Compute the half aperture angle of the entailment cone formed by vectors on
+    the hyperboloid. The given vector would meet the apex of this cone, and the
+    cone itself extends outwards to infinity.
+
+    Args:
+        x: Tensor of shape `(B, D)` giving a batch of space components of
+            vectors on the hyperboloid.
+        curv: Positive scalar denoting negative hyperboloid curvature.
+        min_radius: Radius of a small neighborhood around vertex of the hyperboloid
+            where cone aperture is left undefined. Input vectors lying inside this
+            neighborhood (having smaller norm) will be projected on the boundary.
+        eps: Small float number to avoid numerical instability.
+
+    Returns:
+        Tensor of shape `(B, )` giving the half-aperture of entailment cones
+        formed by input vectors. Values of this tensor lie in `(0, pi/2)`.
+    """
+
+    # Ensure numerical stability in arc-sin by clamping input.
+    asin_input = 2 * min_radius / (torch.norm(x, dim=-1) * curv**0.5 + eps)
+    _half_aperture = torch.asin(torch.clamp(asin_input, min=-1 + eps, max=1 - eps))
+
+    return _half_aperture
+
+
+def oxy_angle(x: Tensor, y: Tensor, curv: float | Tensor = 1.0, eps: float = 1e-8):
+    """
+    Given two vectors `x` and `y` on the hyperboloid, compute the exterior
+    angle at `x` in the hyperbolic triangle `Oxy` where `O` is the origin
+    of the hyperboloid.
+
+    This expression is derived using the Hyperbolic law of cosines.
+
+    Args:
+        x: Tensor of shape `(B, D)` giving a batch of space components of
+            vectors on the hyperboloid.
+        y: Tensor of same shape as `x` giving another batch of vectors.
+        curv: Positive scalar denoting negative hyperboloid curvature.
+
+    Returns:
+        Tensor of shape `(B, )` giving the required angle. Values of this
+        tensor lie in `(0, pi)`.
+    """
+
+    # Calculate time components of inputs (multiplied with `sqrt(curv)`):
+    x_time = torch.sqrt(1 / curv + torch.sum(x**2, dim=-1))
+    y_time = torch.sqrt(1 / curv + torch.sum(y**2, dim=-1))
+
+    # Calculate lorentzian inner product multiplied with curvature. We do not use
+    # the `pairwise_inner` implementation to save some operations (since we only
+    # need the diagonal elements).
+    c_xyl = curv * (torch.sum(x * y, dim=-1) - x_time * y_time)
+
+    # Make the numerator and denominator for input to arc-cosh, shape: (B, )
+    acos_numer = y_time + c_xyl * x_time
+    acos_denom = torch.sqrt(torch.clamp(c_xyl**2 - 1, min=eps))
+
+    acos_input = acos_numer / (torch.norm(x, dim=-1) * acos_denom + eps)
+    _angle = torch.acos(torch.clamp(acos_input, min=-1 + eps, max=1 - eps))
+
+    return _angle

--- a/models/meru/meru.py
+++ b/models/meru/meru.py
@@ -1,0 +1,492 @@
+import torch.nn as nn
+import torch
+
+import timm
+from hydra.utils import instantiate
+from omegaconf import DictConfig
+from .utils import CheckpointManager
+from typing import Callable
+from .text_encoders import TransformerTextEncoder
+import math
+from torch.nn import functional as F
+from . import lorentz
+from models.meru import distributed as dist
+
+
+@timm.models.register_model
+def vit_small_mocov3_patch16_224(**kwargs):
+    """
+    Small Vision Transformer used by MoCo-v3 (https://arxiv.org/abs/2104.02057)
+    This model has 12 heads instead of 6, gives better empirical performance.
+    """
+
+    return timm.models.vision_transformer._create_vision_transformer(
+        "vit_small_patch16_224",
+        patch_size=16,
+        embed_dim=384,
+        depth=12,
+        num_heads=12,
+        **kwargs,
+    )
+
+
+def build_timm_vit(
+    arch: str,
+    global_pool: str = "token",
+    use_sincos2d_pos: bool = True,
+    grad_checkpointing: bool = False,
+):
+    """
+    Build a Vision Transformer (ViT) image encoder from timm.
+
+    Args:
+        global_pool: How to perform global pooling after final layer? If this is
+            `token` (default), we use the [cls] token. For `avg` we perform
+            global average pooling like ConvNets.
+        use_sincos2d_pos: Use a fixed 2D sine-cosine position embedding. If this
+            is False; position embeddings are randomly initialized (and learned).
+    """
+
+    _supported = timm.list_models("vit_*")
+    if arch not in _supported:
+        raise ValueError(f"{arch} is not a supported ViT, choose: {_supported}")
+
+    model = timm.create_model(
+        arch,
+        # `num_classes = 0` does not create the final classification head.
+        num_classes=0,
+        global_pool=global_pool,
+        #
+        # Do not use [CLS] token for models that use global average pooling.
+        class_token=global_pool == "token",
+        #
+        # Use LayerNorm with default `eps = 1e-5` (timm uses 1e-6, not sure why)
+        norm_layer=nn.LayerNorm,
+    )
+
+    model.set_grad_checkpointing(grad_checkpointing)
+
+    # Set `width` attribute to access in model.
+    model.width = model.embed_dim
+
+    # ------------------------------------------------------------------------
+    # 2D sine-cosine embedding for Vision Transformers. This implementation
+    # is adapted from MoCo-v3 (https://github.com/facebookresearch/moco-v3) and
+    # it produces exactly same embeddings.
+    # ------------------------------------------------------------------------
+    if use_sincos2d_pos:
+        h, w = model.patch_embed.grid_size
+        grid_w = torch.arange(w, dtype=torch.float32)
+        grid_h = torch.arange(h, dtype=torch.float32)
+        grid_w, grid_h = torch.meshgrid(grid_w, grid_h)
+
+        assert (
+            model.embed_dim % 4 == 0
+        ), "ViT embed_dim must be divisible by 4 for 2D sin-cos position embedding"
+        pos_dim = model.embed_dim // 4
+
+        omega = torch.arange(pos_dim, dtype=torch.float32) / pos_dim
+        omega = 1.0 / (10000.0**omega)
+        out_w = torch.einsum("m,d->md", [grid_w.flatten(), omega])
+        out_h = torch.einsum("m,d->md", [grid_h.flatten(), omega])
+        pos_emb = torch.cat(
+            [torch.sin(out_w), torch.cos(out_w), torch.sin(out_h), torch.cos(out_h)],
+            dim=1,
+        )[None, :, :]
+
+        if global_pool == "token":
+            pe_token = torch.zeros([1, 1, model.embed_dim], dtype=torch.float32)
+            pos_emb = torch.cat([pe_token, pos_emb], dim=1)
+
+        # Override position embedding.
+        model.pos_embed.data.copy_(pos_emb)
+        model.pos_embed.requires_grad = False
+    return model
+
+
+def callable_to_str(some_callable: Callable) -> str:
+    # Return module and name of a callable (function or class) for OmegaConf.
+    return f"{some_callable.__module__}.{some_callable.__qualname__}"
+
+
+class LazyCall:
+    """
+    Wrap a callable so that when it's called, the call will not be executed, but
+    returns a dict that describes the call. Only supports keyword arguments.
+    """
+
+    def __init__(self, target: Callable):
+        if not callable(target):
+            raise TypeError(f"LazyCall target must be a callable! Got {target}")
+        self.T = target
+
+    def target_str(self):
+        return
+
+    def __call__(self, **kwargs):
+        # Pop `_target_` if it already exists in kwargs. This happens when the
+        # callable target is changed while keeping everything else same.
+        _ = kwargs.pop("_target_", None)
+
+        # Put current target first; it reads better in printed/saved output.
+        kwargs = {"_target_": callable_to_str(self.T), **kwargs}
+        return DictConfig(content=kwargs, flags={"allow_objects": True})
+
+
+class CLIPBaseline(nn.Module):
+    """
+    Our re-implementation of the CLIP model that uses an image-text contrastive
+    loss as a training objective and embeds images and text in a Euclidean space.
+
+    Reference: CLIP paper (https://arxiv.org/abs/2103.00020)
+    """
+
+    def __init__(
+        self,
+        visual: nn.Module,
+        textual: TransformerTextEncoder,
+        embed_dim: int,
+        pixel_mean: tuple[float, float, float] = (0.485, 0.456, 0.406),
+        pixel_std: tuple[float, float, float] = (0.229, 0.224, 0.225),
+    ):
+        """
+        Args:
+            visual: ConvNet or ViT image encoder to compute image features.
+            textual: Transformer-based encoder to compute text features.
+            embed_dim: Size of the visual and textual embedding vectors for
+                computing pairwise similarity matrix.
+            pixel_mean: Normalize input images by this color mean. Default value
+                is of ImageNet color, set to `(0, 0, 0)` for no normalization.
+            pixel_std: Normalize input images by this color std. Default value
+                is of ImageNet color, set to `(1, 1, 1)` for no normalization.
+        """
+        super().__init__()
+        self.visual = visual
+        self.textual = textual
+        self.embed_dim = embed_dim
+
+        # Linear layers to project image and text features such that they have
+        # same size before computing dot-product similarity.
+        self.visual_proj = nn.Linear(visual.width, embed_dim, bias=False)
+        self.textual_proj = nn.Linear(textual.width, embed_dim, bias=False)
+
+        # CLIP-style initialization of projection layers.
+        nn.init.normal_(self.visual_proj.weight, std=visual.width**-0.5)
+        nn.init.normal_(self.textual_proj.weight, std=textual.width**-0.5)
+
+        # Initialize a learnable logit scale parameter.
+        self.logit_scale = nn.Parameter(torch.tensor(1 / 0.07).log())
+
+        # Color mean/std to normalize image.
+        self.register_buffer("pixel_mean", torch.tensor(pixel_mean).view(-1, 1, 1))
+        self.register_buffer("pixel_std", torch.tensor(pixel_std).view(-1, 1, 1))
+
+        # Get rank of current GPU process for gathering features.
+        self._rank = dist.get_rank()
+
+    @property
+    def device(self) -> torch.device:
+        return self.logit_scale.device
+
+    def encode_image(self, images: torch.Tensor, project: bool):
+        """
+        Args:
+            images: Image batch in BCHW format, with pixel values in `[0, 1]`.
+            project: Project features to a unit hypersphere through L2 normalization.
+
+        Returns:
+            Batch of image features of shape `(B, visual.width)`.
+        """
+        images = (images - self.pixel_mean) / self.pixel_std
+        image_feats = self.visual(images)
+        image_feats = self.visual_proj(image_feats)
+
+        if project:
+            image_feats = F.normalize(image_feats, dim=-1)
+
+        return image_feats
+
+    def encode_text(self, tokens: list[torch.Tensor], project: bool):
+        """
+        Args:
+            tokens: List of tensors, each containing text tokens. Tensors may have
+                variable length (they will be padded internally).
+            project: Project features to a unit hypersphere through L2 normalization.
+        """
+
+        # Truncate tokens that are longer than context_length:
+        for idx, inst_tokens in enumerate(tokens):
+            if len(inst_tokens) > self.textual.context_length:
+                eot_token = inst_tokens[-1]
+                inst_tokens = inst_tokens[: self.textual.context_length]
+                inst_tokens[-1] = eot_token
+                tokens[idx] = inst_tokens
+
+        # Pad all tokens on the right.
+        tokens = torch.nn.utils.rnn.pad_sequence(tokens, batch_first=True)
+        tokens = tokens.to(self.device)
+
+        # shape: (batch_size, context_length, textual.width)
+        text_feats = self.textual(tokens)
+
+        # Get features for [EOS] position and apply projection. `[EOS]` token ID
+        # is the largest number in the vocabulary of tokenizer.
+        _eos_indices = tokens.argmax(dim=-1)
+        batch_idxs = torch.arange(text_feats.shape[0])
+        text_feats = text_feats[batch_idxs, _eos_indices]
+        text_feats = self.textual_proj(text_feats)
+
+        if project:
+            text_feats = F.normalize(text_feats, dim=-1)
+
+        return text_feats
+
+    def forward(
+        self, images: torch.Tensor, tokens: list[torch.Tensor]
+    ) -> dict[str, torch.Tensor]:
+        """
+        Args:
+            images: Image batch in BCHW format, with pixel values in `[0, 1]`.
+            tokens: List of tensors, each containing text tokens. Tensors may have
+                variable length (they will be padded internally).
+        """
+
+        # shape: (batch_size, embed_dim)
+        image_feats = self.encode_image(images, project=True)
+        text_feats = self.encode_text(tokens, project=True)
+
+        # Get features from all GPUs to increase negatives for contrastive loss.
+        # These will be lists of tensors with length = world size.
+        all_image_feats = dist.gather_across_processes(image_feats)
+        all_text_feats = dist.gather_across_processes(text_feats)
+
+        # shape: (batch_size * world_size, embed_dim)
+        all_image_feats = torch.cat(all_image_feats, dim=0)
+        all_text_feats = torch.cat(all_text_feats, dim=0)
+
+        # Clamp temperature such that logits are not scaled more than 100x.
+        # ln(100) = ~4.6052
+        self.logit_scale.data = torch.clamp(self.logit_scale.data, max=4.6052)
+        _scale = self.logit_scale.exp()
+
+        # Compute logits for image-text contrastive loss: cosine similarity.
+        image_logits = _scale * image_feats @ all_text_feats.T
+        text_logits = _scale * text_feats @ all_image_feats.T
+
+        # Compute cross entropy loss: we compute log probabilities and take the
+        # diagonal elements as targets: image[i] should match text[i] in batch.
+        # Shift the targets according to rank of GPU process (we assume that all
+        # GPU processes have the same local batch size).
+        batch_size = image_feats.shape[0]
+        targets = torch.arange(batch_size, device=image_logits.device)
+        targets = targets + batch_size * self._rank
+
+        loss = 0.5 * (
+            F.cross_entropy(image_logits, targets)
+            + F.cross_entropy(text_logits, targets)
+        )
+        output_dict = {
+            "loss": loss,
+            "logging": {"contrastive_loss": loss, "logit_scale": _scale},
+        }
+        return output_dict
+
+
+class MERU(CLIPBaseline):
+    """
+    Our MERU model, that modifies CLIP to embed images and text in a hyperbolic
+    space. Modifications are as follows:
+
+    1. Lift embeddings from encoders onto the Lorentz hyperboloid using
+       exponential map operator, instead of projecting via L2-normalization.
+
+    2. Modify the contrastive loss to use the negative Lorentzian distance as
+       a similarity measure instead of cosine similarity.
+
+    3. Use a textual entailment loss to enforce a partial-order relationship
+       between paired text and image embeddings (Note that an equivalent loss
+       for CLIP is not mathematically defined).
+    """
+
+    def __init__(
+        self,
+        visual: nn.Module,
+        textual: TransformerTextEncoder,
+        embed_dim: int,
+        curv_init: float = 1.0,
+        learn_curv: bool = True,
+        entail_weight: float = 0.0,
+        pixel_mean: tuple[float, float, float] = (0.485, 0.456, 0.406),
+        pixel_std: tuple[float, float, float] = (0.229, 0.224, 0.225),
+    ):
+        """
+        Un-documented args are same as `CLIPBaseline`.
+
+        Args:
+            curv_init: Positive scalar that denotes negative Hyperboloid curvature.
+            learn_curv: Whether to learn the curvature parameter during training.
+            entail_weight: Weight for the entailment loss component.
+        """
+        super().__init__(visual, textual, embed_dim, pixel_mean, pixel_std)
+
+        # Initialize curvature parameter. Hyperboloid curvature will be `-curv`.
+        self.curv = nn.Parameter(
+            torch.tensor(curv_init).log(), requires_grad=learn_curv
+        )
+        # When learning the curvature parameter, restrict it in this interval to
+        # prevent training instability.
+        self._curv_minmax = {
+            "max": math.log(curv_init * 10),
+            "min": math.log(curv_init / 10),
+        }
+        self.entail_weight = entail_weight
+
+        # Learnable scalars to ensure that image/text features have an expected
+        # unit norm before exponential map (at initialization).
+        self.visual_alpha = nn.Parameter(torch.tensor(embed_dim**-0.5).log())
+        self.textual_alpha = nn.Parameter(torch.tensor(embed_dim**-0.5).log())
+
+    def encode_image(self, images: torch.Tensor, project: bool):
+        """
+        Args:
+            images: Image batch in BCHW format, with pixel values in `[0, 1]`.
+            project: Lift features from the encoder onto the Hyperboloid.
+
+        Returns:
+            Batch of image features of shape `(B, visual.width)`.
+        """
+
+        # Get Euclidean features from the encoder (without L2 normalization).
+        image_feats = super().encode_image(images, project=False)
+
+        # These features are space components of embeddings in the tangent
+        # space of the Hyperboloid origin (which is Euclidean). Apply projection.
+        if project:
+            image_feats = image_feats * self.visual_alpha.exp()
+            with torch.autocast(self.device.type, dtype=torch.float32):
+                image_feats = lorentz.exp_map0(image_feats, self.curv.exp())
+
+        return image_feats
+
+    def encode_text(self, tokens: list[torch.Tensor], project: bool):
+        """
+        Args:
+            tokens: List of tensors, each containing text tokens. Tensors may have
+                variable length (they will be padded internally).
+            project: Lift features from the encoder onto the Hyperboloid.
+        """
+
+        # Get Euclidean features from the encoder (without L2 normalization).
+        text_feats = super().encode_text(tokens, project=False)
+
+        if project:
+            text_feats = text_feats * self.textual_alpha.exp()
+            with torch.autocast(self.device.type, dtype=torch.float32):
+                text_feats = lorentz.exp_map0(text_feats, self.curv.exp())
+
+        return text_feats
+
+    def forward(
+        self,
+        images: torch.Tensor,
+        tokens: list[torch.Tensor],
+    ) -> dict[str, torch.Tensor]:
+        """
+        Args:
+            images: Image batch in BCHW format, with pixel values in `[0, 1]`.
+            tokens: List of tensors, each containing text tokens. Tensors may have
+                variable length (they will be padded internally).
+        """
+
+        self.curv.data = torch.clamp(self.curv.data, **self._curv_minmax)
+        _curv = self.curv.exp()
+
+        # Clamp scaling factors such that they do not up-scale the feature norms.
+        # Once `exp(scale) = 1`, they can simply be removed during inference.
+        self.visual_alpha.data = torch.clamp(self.visual_alpha.data, max=0.0)
+        self.textual_alpha.data = torch.clamp(self.textual_alpha.data, max=0.0)
+
+        # shape: (batch_size, embed_dim)
+        image_feats = self.encode_image(images, project=True)
+        text_feats = self.encode_text(tokens, project=True)
+
+        # Get features from all GPUs to increase negatives for contrastive loss.
+        # These will be lists of tensors with length = world size.
+        all_image_feats = dist.gather_across_processes(image_feats)
+        all_text_feats = dist.gather_across_processes(text_feats)
+
+        # shape: (batch_size * world_size, embed_dim)
+        all_image_feats = torch.cat(all_image_feats, dim=0)
+        all_text_feats = torch.cat(all_text_feats, dim=0)
+
+        # Compute all necessary loss components. We enclose the entire block with
+        # autocast to force a higher floating point precision.
+        with torch.autocast(self.device.type, dtype=torch.float32):
+            # Compute logits for contrastive loss.
+            image_logits = -lorentz.pairwise_dist(image_feats, all_text_feats, _curv)
+            text_logits = -lorentz.pairwise_dist(text_feats, all_image_feats, _curv)
+
+            # Compute cross entropy loss: we compute log probabilities and take the
+            # diagonal elements as targets: image[i] should match text[i] in batch.
+            # Shift the targets according to rank of GPU process (we assume that all
+            # GPU processes have the same local batch size).
+            batch_size = image_feats.shape[0]
+            targets = torch.arange(batch_size, device=image_logits.device)
+            targets = targets + batch_size * self._rank
+
+            # Clamp temperature such that logits are not scaled more than 100x.
+            # ln(100) = ~4.6052
+            self.logit_scale.data = torch.clamp(self.logit_scale.data, max=4.6052)
+            _scale = self.logit_scale.exp()
+
+            contrastive_loss = 0.5 * (
+                nn.functional.cross_entropy(_scale * image_logits, targets)
+                + nn.functional.cross_entropy(_scale * text_logits, targets)
+            )
+
+            # Hyperbolic entailment loss: text should entail matching image.
+            _angle = lorentz.oxy_angle(text_feats, image_feats, _curv)
+            _aperture = lorentz.half_aperture(text_feats, _curv)
+            entailment_loss = torch.clamp(_angle - _aperture, min=0).mean()
+
+            loss = contrastive_loss
+            if self.entail_weight > 0:
+                loss = loss + self.entail_weight * entailment_loss
+
+        return {
+            "loss": loss,
+            "logging": {
+                "contrastive_loss": contrastive_loss,
+                "entailment_loss": entailment_loss,
+                "logit_scale": _scale,
+                "curv": _curv,
+            },
+        }
+
+
+if __name__ == "__main__":
+    device = (
+        torch.cuda.current_device()
+        if torch.cuda.is_available()
+        else torch.device("cpu")
+    )
+    # modelがc_train
+    model = LazyCall(MERU)(
+        visual=LazyCall(build_timm_vit)(
+            arch="vit_large_patch16_224",
+            global_pool="token",
+            use_sincos2d_pos=True,
+        ),
+        textual=LazyCall(TransformerTextEncoder)(
+            arch="L12_W512", vocab_size=49408, context_length=77
+        ),
+        embed_dim=512,
+        curv_init=1.0,
+        learn_curv=True,
+        entail_weight=0.2,
+    )
+    model.visual.arch = "vit_small_mocov3_patch16_224"
+    device = device or torch.cuda.current_device()
+    model = instantiate(model).to(device).eval()
+    print(model)
+    CheckpointManager(model=model).load("pretrained_weights/meru_vit_s.pth")

--- a/models/meru/text_encoders.py
+++ b/models/meru/text_encoders.py
@@ -1,0 +1,147 @@
+import torch.nn as nn
+import torch
+
+# import timm
+# from hydra.utils import instantiate
+# from omegaconf import DictConfig, ListConfig, OmegaConf
+# from meru.utils import CheckpointManager
+# from typing import Callable
+import re
+from torch.utils.checkpoint import checkpoint
+from collections import OrderedDict
+from typing import Optional
+
+
+class _TransformerBlock(nn.Module):
+    """
+    Single transformer block comprising multi-head self-attention and MLP. Both
+    modules are preceeding by layer normalization. This module is same as PyTorch
+    builtin module `TransformerEncoderLayer` with arguments as
+    (`norm_first=True, dropout=0, activation="gelu"`).
+
+    We adapt this module from CLIP to easily load checkpoints of CLIP and other
+    works that build on CLIP's code. Reference: https://github.com/openai/clip
+    """
+
+    def __init__(self, d_model: int, n_head: int):
+        super().__init__()
+
+        self.attn = nn.MultiheadAttention(d_model, n_head, batch_first=True)
+        self.ln_1 = nn.LayerNorm(d_model)
+        self.mlp = nn.Sequential(
+            OrderedDict(
+                [
+                    ("c_fc", nn.Linear(d_model, d_model * 4)),
+                    ("gelu", nn.GELU()),
+                    ("c_proj", nn.Linear(d_model * 4, d_model)),
+                ]
+            )
+        )
+        self.ln_2 = nn.LayerNorm(d_model)
+
+    def forward(self, x: torch.Tensor, attn_mask: Optional[torch.Tensor] = None):
+        lx = self.ln_1(x)
+        ax = self.attn(lx, lx, lx, need_weights=False, attn_mask=attn_mask)[0]
+        x = x + ax
+        x = x + self.mlp(self.ln_2(x))
+        return x
+
+
+class TransformerTextEncoder(nn.Module):
+    """
+    Text encoder using multiple layers of transformer encoder blocks. It accepts
+    tokenized text sequences, passes them through word/position embedding layers
+    and further processes them through transformer layers.
+
+    All transformer blocks are unidirectional "Pre-LN" variants by default:
+    LayerNorm is placed before attention/MLP layers inside the residual block,
+    and future positions are masked while computing self-attention.
+    """
+
+    def __init__(
+        self,
+        arch: str,
+        vocab_size: int,
+        context_length: int,
+        grad_checkpointing: bool = False,
+    ):
+        """
+        Args:
+            arch: Architecture config for transformer, describing layers, width,
+                and number of attention heads. For example, `L12_W512_A8` has 1
+                layer, 512 width, 8 heads. Width of MLP will always be `4 * W`,
+                per transformer paper. `A` is optional and will default to
+                (`A = H/64`) per transformer paper.
+            vocab_size: Number of tokens in the output vocabulary.
+            context_length: Maximum length of input captions; this is used to
+                create a fixed positional embedding lookup table.
+        """
+        super().__init__()
+        self.vocab_size = vocab_size
+        self.context_length = context_length
+        self.grad_checkpointing = grad_checkpointing
+
+        # Parse architecture str: layers, width, heads, feed-forward size.
+        self.layers = int(re.search(r"L(\d+)", arch).group(1))
+        self.width = int(re.search(r"W(\d+)", arch).group(1))
+
+        # Find heads in architecture else use (H // 64) per (Vaswani et al.)
+        _attn = re.search(r"A(\d+)", arch)
+        self.heads = int(_attn.group(1)) if _attn else self.width // 64
+
+        # Input sequences in forward pass will be right padded with zeroes.
+        # `nn.Embedding` has a `padding_idx` argument to set their embedding as
+        # zero. However, since the blocks are uni-directional, they will never
+        # receive gradients for padded positions.
+        self.token_embed = nn.Embedding(vocab_size, self.width)
+        self.posit_embed = nn.Parameter(torch.empty(context_length, self.width))
+
+        # Make a sequential module of transformer encoder blocks.
+        _resblocks = [
+            _TransformerBlock(self.width, self.heads) for _ in range(self.layers)
+        ]
+        self.resblocks = nn.ModuleList(_resblocks)
+        self.ln_final = nn.LayerNorm(self.width)
+
+        # Generate a unidirectional mask for self-attention. As per PyTorch API,
+        # masked positions are set to `-inf`.
+        attn_mask = torch.triu(
+            torch.full((context_length, context_length), float("-inf")), diagonal=1
+        )
+        self.register_buffer("attn_mask", attn_mask.bool())
+
+        # Initialize all modules like CLIP:
+        nn.init.normal_(self.token_embed.weight, std=0.02)
+        nn.init.normal_(self.posit_embed.data, std=0.01)
+
+        out_proj_std = (2 * self.width * self.layers) ** -0.5
+        for block in self.resblocks:
+            nn.init.normal_(block.attn.in_proj_weight, std=self.width**-0.5)
+            nn.init.normal_(block.attn.out_proj.weight, std=out_proj_std)
+            nn.init.normal_(block.mlp[0].weight, std=(2 * self.width) ** -0.5)
+            nn.init.normal_(block.mlp[2].weight, std=out_proj_std)
+
+    def forward(self, text_tokens: torch.Tensor) -> torch.Tensor:
+        """
+        Obtain features of input text tokens by passing them through transformer
+        blocks. All self-attention layers only attend to past token (left side).
+        """
+
+        max_len = text_tokens.shape[-1]
+        _posit_embed = self.posit_embed[:max_len, :]
+        _attn_mask = self.attn_mask[:max_len, :max_len]
+
+        # shape: (batch_size, context_length, width)
+        token_embeddings = self.token_embed(text_tokens) + _posit_embed
+
+        # Forward pass through transformer, optionally with grad checkpointing.
+        textual_features = token_embeddings
+        for block in self.resblocks:
+            if self.grad_checkpointing and self.training:
+                # shape: (context_length, batch_size, width)
+                textual_features = checkpoint(block, textual_features, _attn_mask)
+            else:
+                textual_features = block(textual_features, _attn_mask)
+
+        textual_features = self.ln_final(textual_features)
+        return textual_features

--- a/models/meru/utils.py
+++ b/models/meru/utils.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import copy
+from pathlib import Path
+
+import torch
+
+# from loguru import logger
+from torch.nn.parallel import DistributedDataParallel
+
+from models.meru import distributed as dist
+
+
+class CheckpointManager:
+    """
+    Utility class to perioidically save PyTorch models and other checkpointables
+    (optimizers, LR schedulers etc., which implement `state_dict` method)
+    during training. For PyTorch `DistributedDataParallel` objects,
+    `state_dict` of the internal model is saved.
+
+    Examples:
+        >>> model = torch.nn.Linear(10, 2)
+        >>> optimizer = torch.optim.Adam(model.parameters())
+        >>> ckpt_manager = CheckpointManager("/tmp", model=model, optimizer=optimizer)
+        >>> for iteration in range(1000):
+        ...     train(model)
+        ...     if iteration % 100 == 0:
+        ...         ckpt_manager.step(iteration)
+    """
+
+    def __init__(
+        self, output_dir: str = "/tmp", keep_recent: int = 100, **checkpointables
+    ):
+        """
+        Args:
+            output_dir: Path to a directory to save checkpoints.
+            keep_recent: Number of recent `k` checkpoints to keep, old checkpoints
+                will be deleted. Set to a very large value to keep all checkpoints.
+            checkpointables: Keyword arguments with any checkpointable objects, for
+                example: model, optimizer, LR scheduler, AMP gradient scaler.
+        """
+        self.output_dir = Path(output_dir)
+        self.keep_recent = keep_recent
+        self._recent_iterations = []
+
+        # Shallow copy, keeps references to tensors as original objects so they
+        # can be updated externally, or loaded in here without needing explicit
+        # synchronization after every operation.
+        self.checkpointables = copy.copy(checkpointables)
+
+    def step(self, iteration: int):
+        """
+        Save a checkpoint; keys match those in :attr:`checkpointables`.
+
+        Args:
+            iteration: Current training iteration. Will be saved with other
+                checkpointables.
+        """
+
+        out_state_dict = {}
+        for key in self.checkpointables:
+            if isinstance(self.checkpointables[key], DistributedDataParallel):
+                out_state_dict[key] = self.checkpointables[key].module.state_dict()
+            else:
+                out_state_dict[key] = self.checkpointables[key].state_dict()
+
+        # We also checkpoint current iteration.
+        out_state_dict["iteration"] = iteration
+
+        # String formatting, assuming we won't train for more than 99M iterations.
+        iter_str = f"{iteration:0>8d}"
+
+        # Save checkpoint corresponding to current iteration.
+        torch.save(out_state_dict, self.output_dir / f"checkpoint_{iter_str}.pth")
+        with (self.output_dir / "last_checkpoint.txt").open("w") as f:
+            f.write(f"checkpoint_{iter_str}.pth")
+
+        # Remove earliest checkpoint if there are more on disk.
+        self._recent_iterations.append(iter_str)
+        if len(self._recent_iterations) > self.keep_recent:
+            oldest_iteration = self._recent_iterations.pop(0)
+            (self.output_dir / f"checkpoint_{oldest_iteration}.pth").unlink()
+
+    def final_step(self):
+        """
+        Save the final checkpoint with name `checkpoint_final.pth`. This method
+        does not update `last_checkpoint.txt` or delete the oldest checkpoint.
+        """
+
+        out_state_dict = {}
+        for key in self.checkpointables:
+            if isinstance(self.checkpointables[key], DistributedDataParallel):
+                out_state_dict[key] = self.checkpointables[key].module.state_dict()
+            else:
+                out_state_dict[key] = self.checkpointables[key].state_dict()
+
+        # Save checkpoint corresponding to current iteration.
+        torch.save(out_state_dict, self.output_dir / "checkpoint_final.pth")
+
+    def resume(self) -> int:
+        """
+        Find the last saved checkpoint in :attr:`output_dir` (from a previous job)
+        and load it to resume the job. This method will log a warning message if
+        no checkpoint is found for loading.
+        """
+
+        # logger.info(f"Attempting to resume job from {self.output_dir}...")
+
+        last_ckpt_info_file = self.output_dir / "last_checkpoint.txt"
+        if last_ckpt_info_file.exists():
+            ckpt_path = last_ckpt_info_file.read_text().strip()
+            # logger.info(f"Found last checkpoint in {self.output_dir}: {ckpt_path}")
+            return self.load(self.output_dir / ckpt_path)
+        else:
+            # logger.warning(
+            #     f"No checkpoint found in {self.output_dir} to resume job! "
+            #     "Hopefully this is the beginning of a fresh job."
+            # )
+            return 0
+
+    def load(self, path: str | Path) -> int:
+        """
+        Load a saved checkpoint from a given file path. This method tries to find
+        each of :attr:`checkpointables` in the file and load their state dict.
+
+        Args:
+            path: Path to a directory/checkpoint saved by :meth:`step`.
+
+        Returns:
+            Iteration corresponding to the loaded checkpoint (to resume training).
+            If iteration is not found in file, this method will return -1.
+        """
+
+        # Each process will log a message after loading checkpoint.
+        rank = dist.get_rank()
+
+        # logger.info(f"Rank {rank}: Loading checkpoint from {path}")
+        checkpoint = torch.load(path, map_location="cpu")
+        # print(type(checkpoint))
+        # print(checkpoint.keys())
+        iteration = checkpoint.pop("iteration", -1)
+
+        # Keep flags of all checkpointables to lo which ones were not loaded.
+        is_loaded = {key: False for key in self.checkpointables}
+
+        # Load each checkpointable from checkpoint.
+        for key in checkpoint:
+            # print(f"checkpointtables: {self.checkpointables}")
+            if key in self.checkpointables:
+                # logger.info(f"Rank {rank}: Loading {key} from {path}")
+
+                if isinstance(self.checkpointables[key], DistributedDataParallel):
+                    self.checkpointables[key].module.load_state_dict(checkpoint[key])
+                else:
+                    # print(key)
+                    # print(checkpoint[key].keys())
+                    self.checkpointables[key].load_state_dict(checkpoint[key])
+
+                is_loaded[key] = True
+            else:
+                # logger.info(f"Rank {rank}: {key} not found in `checkpointables`.")
+                pass
+
+        not_loaded: list[str] = [key for key in is_loaded if not is_loaded[key]]
+        if len(not_loaded) > 0:
+            # logger.info(f"Rank {rank}: Checkpointables not found in file: {not_loaded}")
+            pass
+        return iteration

--- a/models/meru_models.py
+++ b/models/meru_models.py
@@ -1,0 +1,60 @@
+from models.meru.text_encoders import TransformerTextEncoder
+from models.meru.meru import LazyCall, build_timm_vit, CheckpointManager, MERU
+import torch.nn as nn
+import torch
+from hydra.utils import instantiate
+
+
+class MeruModel(nn.Module):
+    def __init__(
+        self,
+        visual: nn.Module,
+        textual: TransformerTextEncoder = LazyCall(TransformerTextEncoder)(
+            arch="L12_W512", vocab_size=49408, context_length=77
+        ),
+        embed_dim: int = 512,
+        curv_init: float = 1.0,
+        learn_curv: bool = True,
+        entail_weight: float = 0.0,
+        pixel_mean: tuple[float, float, float] = (0.485, 0.456, 0.406),
+        pixel_std: tuple[float, float, float] = (0.229, 0.224, 0.225),
+        num_classes=1,
+        channels=512,
+    ):
+        super(MeruModel, self).__init__()
+        device = (
+            torch.cuda.current_device()
+            if torch.cuda.is_available()
+            else torch.device("cpu")
+        )
+        model = LazyCall(MERU)(
+            visual=LazyCall(build_timm_vit)(
+                arch="vit_large_patch16_224",
+                global_pool="token",
+                use_sincos2d_pos=True,
+            ),
+            textual=LazyCall(TransformerTextEncoder)(
+                arch="L12_W512", vocab_size=49408, context_length=77
+            ),
+            embed_dim=512,
+            curv_init=1.0,
+            learn_curv=True,
+            entail_weight=0.2,
+        )
+        # 今回はModel: MERU ViT-smallを使うことにする
+        model.visual.arch = "vit_small_mocov3_patch16_224"
+        device = device or torch.cuda.current_device()
+        model = instantiate(model).to(device).eval()
+        CheckpointManager(model=model).load("pretrained_weights/meru_vit_s.pth")
+        self.model = model
+        # MERUにはない、新しいFC層をつける
+        self.fc = nn.Linear(channels, num_classes)
+
+    def forward(
+        self, images: torch.Tensor, return_feature=False
+    ) -> dict[str, torch.Tensor]:
+
+        image_feats = self.model.encode_image(images, project=True)
+        if return_feature:
+            return image_feats
+        return self.fc(image_feats)

--- a/validate.py
+++ b/validate.py
@@ -291,7 +291,15 @@ if __name__ == "__main__":
 
     model = get_model(opt.arch)
     state_dict = torch.load(opt.ckpt, map_location="cpu")
-    model.fc.load_state_dict(state_dict)
+    if opt.arch == "Meru:Vit-S":
+        model.load_state_dict(state_dict["model"])
+    elif opt.arch == "Dino:Vit-B/14":
+        model.load_state_dict(state_dict["model"])
+    elif opt.arch == "CLIP:ViT-L/14":
+        model.fc.load_state_dict(state_dict)
+    else:
+        raise ValueError()
+
     print("Model loaded..")
     model.eval()
     model.cuda()


### PR DESCRIPTION
## Why
MERUモデルを追加したい

## Change Overview

- MERUモデルに必要なファイルを追加
- class MeruModelを追加
- __init__pyとvalidate.pyを更新

## Memo
MERUのモデルは以下のものです
https://github.com/facebookresearch/meru

## How to test
trainの場合

```bash

poetry run python train.py --name=Meru --wang2020_data_path=datasets/ --data_mode=wang2020  --arch=Meru:Vit-S  --fix_backbone
```

validateの場合
ckptは置き換えてください
```bash
poetry run python validate.py  --arch=Meru:Vit-S   --ckpt=pretrained_weights/weights.pth   --result_folder=meru_result
```

## Note 
今回はMERUの
Model: [MERU ViT-small](https://dl.fbaipublicfiles.com/meru/meru_vit_s.pth) and config: [train_meru_vit_s.py](https://github.com/facebookresearch/meru/blob/main/configs/train_meru_vit_s.py)
を使用することを想定しています。
重みをダウンロードしてください