### PR TITLE
Feat/add deit models

### DIFF
--- a/models/__init__.py
+++ b/models/__init__.py
@@ -2,6 +2,7 @@ from .clip_models import CLIPModel
 from .imagenet_models import ImagenetModel
 from .dinov2_models import DinoModel
 from .meru_models import MeruModel
+from .deit_models import DeitModel
 
 
 VALID_NAMES = [
@@ -28,8 +29,9 @@ VALID_NAMES = [
     "CLIP:ViT-B/16",
     "CLIP:ViT-L/14",
     "CLIP:ViT-L/14@336px",
-    "Meru:Vit-S",
+    "Meru:Vit-B",
     "Dino:Vit-B/14",
+    "Deit:ViT-B/16",
 ]
 
 
@@ -43,5 +45,7 @@ def get_model(name):
         return DinoModel(name[5:])
     elif name.startswith("Meru:"):
         return MeruModel(name[5:])
+    elif name.startswith("Deit:"):
+        return DeitModel(name[5:])
     else:
         assert False

--- a/models/deit_models.py
+++ b/models/deit_models.py
@@ -1,0 +1,35 @@
+import torch.nn as nn
+import torch
+import timm
+
+
+class DeitModel(nn.Module):
+    def __init__(self, name, num_classes=1, channels=768):
+        super(DeitModel, self).__init__()
+        self.model = timm.models.create_model(
+            "vit_base_patch16_224",
+            pretrained=False,
+            drop_rate=0.0,
+            drop_path_rate=0.1,
+            num_classes=21000,
+        )
+        state_dict = torch.load(
+            "pretrained_weights/vit_base_with_visualatom_21k.pth.tar",
+            map_location="cpu",
+        )
+        self.model.load_state_dict(state_dict["state_dict"], strict=False)
+        self.model.head = nn.Identity()
+        self.model.head_drop = nn.Identity()
+        self.fc = nn.Linear(channels, num_classes)
+
+    def forward(self, x, return_feature=False):
+        features = self.model(x)
+        if return_feature:
+            return features
+        return self.fc(features)
+
+# いま行っていることのメモ
+#   (norm): LayerNorm((768,), eps=1e-06, elementwise_affine=True)
+#   (fc_norm): Identity()
+#   (head_drop): Dropout(p=0.0, inplace=False) -> Identity()
+#   (head): Linear(in_features=768, out_features=21000, bias=True) -> Identity()

--- a/validate.py
+++ b/validate.py
@@ -291,12 +291,16 @@ if __name__ == "__main__":
 
     model = get_model(opt.arch)
     state_dict = torch.load(opt.ckpt, map_location="cpu")
-    if opt.arch == "Meru:Vit-S":
+    if opt.arch == "Meru:Vit-B":
         model.load_state_dict(state_dict["model"])
     elif opt.arch == "Dino:Vit-B/14":
         model.load_state_dict(state_dict["model"])
     elif opt.arch == "CLIP:ViT-L/14":
-        model.fc.load_state_dict(state_dict)
+        # 論文の学習済みの重みを使用する場合
+        # model.fc.load_state_dict(state_dict)
+        model.load_state_dict(state_dict["model"])
+    elif opt.arch == "Deit:ViT-B/16":
+        model.load_state_dict(state_dict["model"])
     else:
         raise ValueError()
 


### PR DESCRIPTION
# Issue URL
visualatomで学習済みのdeit(vit)で学習をしたい

# Change overview
 DeitModelを追加

# How to test
```
poetry run python train.py  --name=deit --wang2020_data_path=original_datasets/  --data_mode=wang2020  --arch=Deit:ViT-B/16  --fix_backbone
```

# Note for reviewers
`pretrained_weights/vit_base_with_visualatom_21k.pth.tar`に学習済みの重みを置く想定です
https://github.com/masora1030/CVPR2023-FDSL-on-VisualAtom/tree/de80c6972f99a57238633ba13b5a06a846272f30

モデルについての参考です
https://huggingface.co/google/vit-base-patch16-224