### PR TITLE
:lion: add umap

### DIFF
--- a/visualization/dimension_reduction.py
+++ b/visualization/dimension_reduction.py
@@ -1,0 +1,134 @@
+from typing import cast
+
+import numpy as np
+from sklearn.manifold import TSNE  # type: ignore
+from umap import UMAP  # type: ignore
+
+
+def transform_data(
+    data: np.ndarray,
+    transform_algo: str,
+    perplexity: float,
+    n_components: int,
+    n_neighbors: int,
+    min_dist: float,
+    metric: str,
+) -> np.ndarray:
+    """Transform input data into an embedded space and return that
+    transformed output.
+
+    Args:
+        data (np.ndarray): A input data whose shape have to be
+            [number_of_samples, dimension_of_features].
+        transform_algo (str): A name of the dimension reduction algorithm.
+        perplexity (float): The perplexity is related to the number of
+            nearest neighbors that is used in other manifold learning
+            algorithms. Larger datasets usually require a larger
+            perplexity. Consider selecting a value between 5 and 50.
+        n_components (int): A dimension of the embedded space.
+        n_neighbors (int): The size of local neighborhood (in terms of
+            number of neighboring sample points) used for manifold
+            approximation. Larger values result in more global views
+            of the manifold, while smaller values result in more
+            local data being preserved. In general values should be
+            in the range 2 to
+        min_dist (float): The effective minimum distance between
+            embedded points. Smaller values will result in a more
+            clustered/clumped embedding where nearby points on the
+            manifold are drawn closer together, while larger values
+            will result on a more even dispersal of points.
+        metric (str): The metric to use to compute distances in high
+            dimensional space. If “precomputed”, an affinity matrix is
+            expected as input.
+
+    Returns:
+        np.ndarray: A transformed output whose shape should be
+            [number_of_samples, n_components].
+
+    """
+    if transform_algo == "tsne":
+        # 受け皿　＝　返値のある関数
+        transformed_data = transform_tsne(
+            data=data,
+            perplexity=perplexity,
+            n_components=n_components,
+        )
+
+    # 呼び出すときは引数に実際に代入する文字や数字を書く
+    # 代入するのが変数でもいいよ
+    elif transform_algo == "umap":
+        transformed_data = transform_umap(
+            data=data,
+            n_neighbors=n_neighbors,
+            min_dist=min_dist,
+            metric=metric,
+        )
+    else:
+        raise NotImplementedError(
+            f"あなたが指定したアルゴリズムは{transform_algo}です。これは対応していません。"
+        )
+    # どっちもtransformed_dataで返す
+    return transformed_data
+
+
+def transform_tsne(
+    data: np.ndarray,
+    perplexity: float = 5.0,
+    n_components: int = 2,
+) -> np.ndarray:
+    """Fit input data into an T-SNE embedded space and return that
+    transformed output.
+
+    Args:
+        data (np.ndarray): A input data whose shape have to be
+            [number_of_samples, dimension_of_features].
+        perplexity (float): The perplexity is related to the number of
+            nearest neighbors that is used in other manifold learning
+            algorithms. Larger datasets usually require a larger
+            perplexity. Consider selecting a value between 5 and 50.
+        n_components (int): A dimension of the T-SNE embedded space.
+
+    Returns:
+        np.ndarray: A transformed output whose shape should be
+            [number_of_samples, n_components].
+
+    """
+    tsne = TSNE(perplexity=perplexity, n_components=n_components, random_state=0)
+    return cast(np.ndarray, tsne.fit_transform(data))
+
+
+# 定義するときは変数の名前と型を書いておく
+def transform_umap(
+    data: np.ndarray,
+    n_neighbors: int,
+    min_dist: float,
+    metric: str = "correlation",
+) -> np.ndarray:
+    """Fit input data into an UMAP embedded space and return that
+    transformed output.
+
+    Args:
+        data (np.ndarray): A input data whose shape have to be
+            [number_of_samples, dimension_of_features].
+        n_neighbors (int): The size of local neighborhood (in terms of
+            number of neighboring sample points) used for manifold
+            approximation. Larger values result in more global views
+            of the manifold, while smaller values result in more
+            local data being preserved. In general values should be
+            in the range 2 to
+        min_dist (float): The effective minimum distance between
+            embedded points. Smaller values will result in a more
+            clustered/clumped embedding where nearby points on the
+            manifold are drawn closer together, while larger values
+            will result on a more even dispersal of points.
+        metric (str): The metric to use to compute distances in high
+            dimensional space. If “precomputed”, an affinity matrix is
+            expected as input.
+
+    Returns:
+        np.ndarray: A transformed output whose shape should be
+            [number_of_samples, n_components].
+
+    """
+    umap = UMAP(n_neighbors=n_neighbors, min_dist=min_dist, metric=metric)
+    return cast(np.ndarray, umap.fit_transform(data))

--- a/visualization/extract_features.py
+++ b/visualization/extract_features.py
@@ -1,0 +1,168 @@
+import pathlib
+from typing import List, NamedTuple
+
+import numpy as np
+import torch
+
+from validate import RealFakeDataset
+import argparse
+from models import get_model
+from dataset_paths import DATASET_PATHS
+import random
+
+
+class ExtractFeaturesReturn(NamedTuple):
+    """ExtractFeaturesの返り値として使うNamedTuple.
+
+    Attributes:
+        labels_list (List[np.ndarray]): クラスラベル.
+        features_list (List[np.ndarray]): 特徴量.
+
+    """
+
+    labels_list: List[np.ndarray]
+    features_list: List[np.ndarray]
+
+
+SEED = 0
+
+
+def set_seed():
+    torch.manual_seed(SEED)
+    torch.cuda.manual_seed(SEED)
+    np.random.seed(SEED)
+    random.seed(SEED)
+
+
+def extract_features() -> ExtractFeaturesReturn:
+    """特徴量などの情報を抽出する.
+
+    Returns:
+        ExtractFeaturesReturn: 特徴量などの情報.
+
+    """
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    parser.add_argument(
+        "--real_path",
+        type=str,
+        default="datasets_gigagan/test/",
+        help="dir name or a pickle",
+    )
+    parser.add_argument(
+        "--fake_path",
+        type=str,
+        default="datasets_gigagan/test/",
+        help="dir name or a pickle",
+    )
+    parser.add_argument(
+        "--data_mode", type=str, default="wang2020", help="wang2020 or ours"
+    )
+    parser.add_argument("--key", type=str, default="gigagan", help="")
+    parser.add_argument(
+        "--max_sample",
+        type=int,
+        default=1000,
+        help="only check this number of images for both fake/real",
+    )
+
+    parser.add_argument("--arch", type=str, default="Deit:ViT-B/16")
+    parser.add_argument("--batch_size", type=int, default=128)
+
+    parser.add_argument(
+        "--jpeg_quality",
+        type=int,
+        default=None,
+        help="100, 90, 80, ... 30. Used to test robustness of our model. Not apply if None",
+    )
+    parser.add_argument(
+        "--gaussian_sigma",
+        type=int,
+        default=None,
+        help="0,1,2,3,4.     Used to test robustness of our model. Not apply if None",
+    )
+
+    opt = parser.parse_args()
+
+    model = get_model(opt.arch)
+
+    print("Model loaded..")
+
+    model.eval()
+    model.cuda()
+
+    if (opt.real_path is None) or (opt.fake_path is None) or (opt.data_mode is None):
+        dataset_paths = DATASET_PATHS
+    else:
+        dataset_paths = [
+            dict(
+                real_path=opt.real_path,
+                fake_path=opt.fake_path,
+                data_mode=opt.data_mode,
+                key=opt.key,
+            )
+        ]
+
+    for dataset_path in dataset_paths:
+        set_seed()
+
+        dataset = RealFakeDataset(
+            dataset_path["real_path"],
+            dataset_path["fake_path"],
+            dataset_path["data_mode"],
+            opt.max_sample,
+            opt.arch,
+            jpeg_quality=opt.jpeg_quality,
+            gaussian_sigma=opt.gaussian_sigma,
+        )
+
+        loader = torch.utils.data.DataLoader(
+            dataset, batch_size=opt.batch_size, shuffle=False, num_workers=4
+        )
+
+    labels_list: List[np.ndarray] = list()
+    features_list: List[np.ndarray] = list()
+
+    for img, label in loader:
+        labels_list.append(label.cpu().data.numpy())
+        img = img.cuda()
+        if opt.arch == "Meru:Vit-B":
+            with torch.no_grad():
+                features = model.model.encode_image(img, project=False)
+        elif opt.arch == "CLIP:ViT-L/14":
+            with torch.no_grad():
+                features = model.model.encode_image(img)
+        elif opt.arch == "Deit:ViT-B/16":
+            with torch.no_grad():
+                features = model.model.encode_image(img)
+        else:
+            with torch.no_grad():
+                features = model.model(img)
+
+        features_list.append(features.cpu().data.numpy())
+
+    return ExtractFeaturesReturn(
+        labels_list=labels_list,
+        features_list=features_list,
+    )
+
+
+def main() -> None:
+    """特徴量と画像の真のラベルを抽出して保存する."""
+
+    extracted_features = extract_features()
+
+    output_dir = pathlib.Path("outputs")
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # ファイル名は適宜変更してください　# TODO: ファイル名の変更を引数で指定できるようにする
+    np.savez_compressed(
+        output_dir / "features_deit_gigagan.npz",
+        labels=np.concatenate(extracted_features.labels_list),
+        features=np.concatenate(extracted_features.features_list),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/visualization/visualize_plot.py
+++ b/visualization/visualize_plot.py
@@ -1,0 +1,311 @@
+import base64
+from io import BytesIO
+from typing import Any
+
+import dash  # type: ignore
+import dash_bootstrap_components as dbc  # type: ignore
+import numpy as np
+import plotly.express as px  # type: ignore
+import plotly.graph_objs as go  # type: ignore
+from dash import dcc, html
+from dash.dependencies import Input, Output  # type: ignore
+from PIL import Image
+
+from visualization.dimension_reduction import transform_umap
+
+# For detail please check original docs:
+# https://umap-learn.readthedocs.io/en/latest/parameters.html#metric
+UMAP_METRICS = {
+    "cosine",
+    "correlation",
+    "euclidean",
+}
+
+
+def numpy_to_b64(image: np.ndarray) -> str:
+    """Convert image data from 0-16 to 0-255. This is a sample specific
+    function.
+    """
+    im_pil = Image.fromarray(image)
+    buff = BytesIO()
+    im_pil.save(buff, format="png")
+    im_b64 = base64.b64encode(buff.getvalue()).decode("utf-8")
+    return im_b64
+
+
+def create_app(
+    labels: np.ndarray,
+    # predicted_labels: np.ndarray,
+    features: np.ndarray,
+) -> dash.Dash:
+    """Create Dash application to make easy to see dashboard.
+
+    Args:
+        labels (np.ndarray): A np.ndarray of true label values. Its
+            shape should be [batch].
+        predicted_labels (np.ndarray): A np.ndarray of predicted label
+            values. Its shape should be [batch].
+        features (np.ndarray): A np.ndarray of extracted features. Its
+            shape should be [batch, feature_dim].
+
+    Returns:
+        dash.Dash: A created Dash application.
+
+    """
+    app = dash.Dash(external_stylesheets=[dbc.themes.FLATLY])
+
+    # Define modules which are displayed as sidebar.
+    sidebar = html.Div(
+        [
+            dbc.Row(
+                [
+                    html.H5(
+                        "でぃーぷとぅるーす☆がーでぃあんず",
+                        style={
+                            "margin-top": "20px",
+                            "margin-left": "20px",
+                        },
+                    )
+                ],
+                style={"height": "5vh"},
+                className="bg-primary text-white font-italic",
+            ),
+            dbc.Row(
+                [
+                    html.Div(
+                        [
+                            # metric
+                            html.P(
+                                "metric",
+                                style={
+                                    "margin-top": "8px",
+                                    "margin-bottom": "4px",
+                                },
+                                className="font-weight-bold",
+                            ),
+                            dcc.Dropdown(
+                                id="metric-picker",
+                                multi=False,
+                                value="cosine",
+                                options=[
+                                    {"label": x, "value": x} for x in UMAP_METRICS
+                                ],
+                                style={"width": "320px"},
+                            ),
+                            # n_neighbors
+                            html.P(
+                                "n_neighbors",
+                                style={
+                                    "margin-top": "8px",
+                                    "margin-bottom": "4px",
+                                },
+                                className="font-weight-bold",
+                            ),
+                            dcc.Slider(
+                                5,
+                                100,
+                                step=1,
+                                value=5,
+                                marks={
+                                    5: "5",
+                                    100: "100",
+                                },
+                                tooltip={
+                                    "placement": "bottom",
+                                    "always_visible": True,
+                                },
+                                id="n_neighbors-slider",
+                            ),
+                            # min_dist
+                            html.P(
+                                "min_dist",
+                                style={
+                                    "margin-top": "8px",
+                                    "margin-bottom": "4px",
+                                },
+                                className="font-weight-bold",
+                            ),
+                            dcc.Slider(
+                                0.0,
+                                0.99,
+                                step=0.01,
+                                value=0.3,
+                                marks={
+                                    0.0: "0.0",
+                                    0.99: "0.99",
+                                },
+                                tooltip={
+                                    "placement": "bottom",
+                                    "always_visible": True,
+                                },
+                                id="min_dist-slider",
+                            ),
+                        ]
+                    )
+                ],
+                style={"height": "50vh", "margin": "8px"},
+            ),
+        ]
+    )
+
+    # Define modules which are displayed as main content.
+    content = html.Div(
+        [
+            dbc.Row(
+                [
+                    dbc.Col(
+                        [
+                            html.Div(
+                                [
+                                    html.H3(
+                                        "UMAP Visualization",
+                                        style={
+                                            "margin-top": "16px",
+                                            "margin-bottom": "4px",
+                                        },
+                                        className="font-weight-bold",
+                                    ),
+                                    dcc.Graph(
+                                        id="dimension-reduction-graph",
+                                        className="bg-light",
+                                    ),
+                                ]
+                            ),
+                        ]
+                    )
+                ],
+                style={"height": "60vh", "margin": "16px"},
+            ),
+            dbc.Row(
+                [
+                    dbc.Col(
+                        [
+                            html.H4(
+                                id="label",
+                                className="font-weight-bold",
+                            ),
+                            html.H4(
+                                id="predicted-label",
+                                className="font-weight-bold",
+                            ),
+                        ]
+                    )
+                ],
+                style={"height": "40vh", "margin": "16px"},
+            ),
+            # dbc.Row(
+            #     [
+            #         dbc.Col(
+            #             [
+            #                 html.Div(
+            #                     [
+            #                         html.H4(
+            #                             "Original Image",
+            #                             className="font-weight-bold",
+            #                         ),
+            #                         html.Div(id="image"),
+            #                     ],
+            #                 )
+            #             ],
+            #         ),
+            #     ],
+            #     style={
+            #         "height": "50vh",
+            #         "margin-top": "16px",
+            #         "margin-left": "16px",
+            #         "margin-bottom": "8px",
+            #         "margin-right": "8px",
+            #     },
+            # ),
+        ]
+    )
+
+    # Define total layout.
+    app.layout = dbc.Container(
+        [
+            dbc.Row(
+                [
+                    dbc.Col(sidebar, width=3, className="bg-light"),
+                    dbc.Col(content, width=9),
+                ]
+            ),
+        ],
+        fluid=True,
+    )
+
+    # Define callback functions from here.
+    @app.callback(
+        Output("label", "children"),
+        [Input("dimension-reduction-graph", "hoverData")],
+    )
+    def display_label(hover_data: Any) -> str:
+        """Callback to change displaying label dynamically."""
+        if hover_data:
+            idx = hover_data["points"][0]["pointIndex"]
+            return f"Label: {labels[idx]}"
+
+        return "Label:"
+
+    # @app.callback(
+    #     Output("predicted-label", "children"),
+    #     [Input("dimension-reduction-graph", "hoverData")],
+    # )
+    # def display_predicted_label(hover_data: Any) -> str:
+    #     """Callback to change displaying predicted label dynamically."""
+    #     if hover_data:
+    #         idx = hover_data["points"][0]["pointIndex"]
+    #         return f"Predicted label: {predicted_labels[idx]}"
+
+    #     return "Predicted label:"
+
+    @app.callback(
+        Output("dimension-reduction-graph", "figure"),
+        [
+            Input("metric-picker", "value"),
+            Input("n_neighbors-slider", "value"),
+            Input("min_dist-slider", "value"),
+        ],
+    )
+    def update_figure(metric: Any, n_neighbors: Any, min_dist: Any) -> go.Figure:
+        """Callback to change displaying figure dynamically."""
+        transformed_data = transform_umap(
+            data=features,
+            n_neighbors=int(n_neighbors),
+            min_dist=float(min_dist),
+            metric=metric,
+        )
+
+        figure = px.scatter(
+            transformed_data,
+            x=0,
+            y=1,
+            # color=[str(label) for label in labels.tolist()],
+            color=labels,
+            color_continuous_scale=px.colors.qualitative.Plotly,
+            # color_continuous_scale=px.colors.sequential.Teal,
+        )
+
+        return figure
+
+    return app
+
+
+if __name__ == "__main__":
+    import argparse
+    import pathlib
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-i", dest="input_path", type=pathlib.Path, required=True)
+    parser.add_argument("-n", dest="num_data", type=int, default=10000)
+    args = parser.parse_args()
+
+    data = np.load(args.input_path)
+
+    print(f"data['features'][0].shape: {data['features'][0].shape}")
+
+    app = create_app(
+        data["labels"][: args.num_data],
+        # data["predicted_labels"][: args.num_data],
+        data["features"][: args.num_data],
+    )
+    app.run_server(host="0.0.0.0", port=8050, debug=True)


### PR DESCRIPTION
# Issue

UMAPでそれぞれの特徴空間を可視化してみる

# Change overview

extract_features.pyで特徴量をnpzファイルに詰め込む
visualize_plot.pyで可視化を行う

# How to test

ここでは、データセット・モデルのアーキテクチャごとにnpzが吐き出されます
保存されるnpzファイルの名前はべた書きなので、申し訳ありませんがpyファイルで直接かきかえてください。
```
poetry run python visualization/extract_features.py --real_path datasets/test/progan/ --fake_path datasets/test/progan/ --max_sample 1000 --arch CLIP:ViT-L/14 
```
```
poetry run python visualization/visualize_plot.py  -i xxxx.npz
```
Webページに可視化結果がのっています

# Note for reviewers

ポートの設定を上手く行わないと可視化できないことがありますので、ご注意ください。

# TODO: ファイル名の変更を引数で指定できるようにする