### PR TITLE
:fish: update umap

### DIFF
--- a/visualization/extract_features.py
+++ b/visualization/extract_features.py
@@ -4,6 +4,7 @@ from typing import List, NamedTuple
 import numpy as np
 import torch
 
+from visualization.umap.realfake_dataset_umap import RealFakeUmapDataset
 from validate import RealFakeDataset
 import argparse
 from models import get_model
@@ -41,50 +42,6 @@ def extract_features() -> ExtractFeaturesReturn:
         ExtractFeaturesReturn: 特徴量などの情報.
 
     """
-    parser = argparse.ArgumentParser(
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter
-    )
-    parser.add_argument(
-        "--real_path",
-        type=str,
-        default="datasets_gigagan/test/",
-        help="dir name or a pickle",
-    )
-    parser.add_argument(
-        "--fake_path",
-        type=str,
-        default="datasets_gigagan/test/",
-        help="dir name or a pickle",
-    )
-    parser.add_argument(
-        "--data_mode", type=str, default="wang2020", help="wang2020 or ours"
-    )
-    parser.add_argument("--key", type=str, default="gigagan", help="")
-    parser.add_argument(
-        "--max_sample",
-        type=int,
-        default=1000,
-        help="only check this number of images for both fake/real",
-    )
-
-    parser.add_argument("--arch", type=str, default="Deit:ViT-B/16")
-    parser.add_argument("--batch_size", type=int, default=128)
-
-    parser.add_argument(
-        "--jpeg_quality",
-        type=int,
-        default=None,
-        help="100, 90, 80, ... 30. Used to test robustness of our model. Not apply if None",
-    )
-    parser.add_argument(
-        "--gaussian_sigma",
-        type=int,
-        default=None,
-        help="0,1,2,3,4.     Used to test robustness of our model. Not apply if None",
-    )
-
-    opt = parser.parse_args()
-
     model = get_model(opt.arch)
 
     print("Model loaded..")
@@ -104,43 +61,62 @@ def extract_features() -> ExtractFeaturesReturn:
             )
         ]
 
+    labels_list: List[np.ndarray] = list()
+    features_list: List[np.ndarray] = list()
+
     for dataset_path in dataset_paths:
         set_seed()
 
-        dataset = RealFakeDataset(
-            dataset_path["real_path"],
-            dataset_path["fake_path"],
-            dataset_path["data_mode"],
-            opt.max_sample,
-            opt.arch,
-            jpeg_quality=opt.jpeg_quality,
-            gaussian_sigma=opt.gaussian_sigma,
-        )
+        if opt.gan_dm:
+            dataset = RealFakeUmapDataset(
+                dataset_path["real_path"],
+                dataset_path["fake_path"],
+                dataset_path["data_mode"],
+                opt.max_sample,
+                dataset_path["key"],
+                opt.arch,
+                jpeg_quality=opt.jpeg_quality,
+                gaussian_sigma=opt.gaussian_sigma,
+            )
+        else:
+            dataset = RealFakeDataset(
+                dataset_path["real_path"],
+                dataset_path["fake_path"],
+                dataset_path["data_mode"],
+                opt.max_sample,
+                opt.arch,
+                jpeg_quality=opt.jpeg_quality,
+                gaussian_sigma=opt.gaussian_sigma,
+            )
 
         loader = torch.utils.data.DataLoader(
             dataset, batch_size=opt.batch_size, shuffle=False, num_workers=4
         )
 
-    labels_list: List[np.ndarray] = list()
-    features_list: List[np.ndarray] = list()
+        for img, label in loader:
+            labels_list.append(label.cpu().data.numpy())
+            img = img.cuda()
+            if opt.arch == "Meru:Vit-B":
+                with torch.no_grad():
+                    features = model.model.encode_image(img, project=False)
+            elif opt.arch == "SynCLR:ViT-B/16" or opt.arch == "StableRep:ViT-B/16":
+                with torch.no_grad():
+                    features = model.model.forward_features(img)
+            elif (
+                opt.arch == "CLIP:ViT-B/16"
+                or opt.arch == "Open_CLIPE32:ViT-B/16"
+                or opt.arch == "Deit:ViT-B/16"
+            ):
+                with torch.no_grad():
+                    features = model.model.encode_image(img)
+            elif opt.arch == "Dino:Vit-B/14":
+                with torch.no_grad():
+                    features = model.model(img)
+            else:
+                with torch.no_grad():
+                    features = model.model(img)
 
-    for img, label in loader:
-        labels_list.append(label.cpu().data.numpy())
-        img = img.cuda()
-        if opt.arch == "Meru:Vit-B":
-            with torch.no_grad():
-                features = model.model.encode_image(img, project=False)
-        elif opt.arch == "CLIP:ViT-L/14":
-            with torch.no_grad():
-                features = model.model.encode_image(img)
-        elif opt.arch == "Deit:ViT-B/16":
-            with torch.no_grad():
-                features = model.model.encode_image(img)
-        else:
-            with torch.no_grad():
-                features = model.model(img)
-
-        features_list.append(features.cpu().data.numpy())
+            features_list.append(features.cpu().data.numpy())
 
     return ExtractFeaturesReturn(
         labels_list=labels_list,
@@ -148,21 +124,69 @@ def extract_features() -> ExtractFeaturesReturn:
     )
 
 
-def main() -> None:
+def main(file_name) -> None:
     """特徴量と画像の真のラベルを抽出して保存する."""
 
     extracted_features = extract_features()
 
     output_dir = pathlib.Path("outputs")
     output_dir.mkdir(parents=True, exist_ok=True)
-
-    # ファイル名は適宜変更してください　# TODO: ファイル名の変更を引数で指定できるようにする
     np.savez_compressed(
-        output_dir / "features_deit_gigagan.npz",
+        output_dir / file_name,
         labels=np.concatenate(extracted_features.labels_list),
         features=np.concatenate(extracted_features.features_list),
     )
 
 
 if __name__ == "__main__":
-    main()
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    parser.add_argument(
+        "--real_path",
+        type=str,
+        default="datasets/test/progan/",
+        help="dir name or a pickle",
+    )
+    parser.add_argument(
+        "--fake_path",
+        type=str,
+        default="datasets/test/progan/",
+        help="dir name or a pickle",
+    )
+    parser.add_argument(
+        "--data_mode", type=str, default="wang2020", help="wang2020 or ours"
+    )
+    parser.add_argument("--key", type=str, default="progan", help="")
+    parser.add_argument(
+        "--max_sample",
+        type=int,
+        default=1000,
+        help="only check this number of images for both fake/real",
+    )
+
+    parser.add_argument("--arch", type=str, default="Open_CLIPE32:ViT-B/16")
+    parser.add_argument("--batch_size", type=int, default=128)
+
+    parser.add_argument(
+        "--jpeg_quality",
+        type=int,
+        default=None,
+        help="100, 90, 80, ... 30. Used to test robustness of our model. Not apply if None",
+    )
+    parser.add_argument(
+        "--gaussian_sigma",
+        type=int,
+        default=None,
+        help="0,1,2,3,4.     Used to test robustness of our model. Not apply if None",
+    )
+    parser.add_argument(
+        "--gan_dm",
+        action="store_true",
+        default=False,
+    )
+    parser.add_argument(
+        "--file_name", type=str, default="otamesi.npz", help="file name to save"
+    )
+    opt = parser.parse_args()
+    main(opt.file_name)

--- a/visualization/umap/realfake_dataset_umap.py
+++ b/visualization/umap/realfake_dataset_umap.py
@@ -1,0 +1,249 @@
+import os
+import torch
+import torchvision.transforms as transforms
+import torch.utils.data
+import numpy as np
+from sklearn.metrics import average_precision_score, accuracy_score
+from torch.utils.data import Dataset
+from PIL import Image
+import pickle
+from io import BytesIO
+from copy import deepcopy
+
+import random
+from scipy.ndimage.filters import gaussian_filter
+
+SEED = 0
+
+
+def set_seed():
+    torch.manual_seed(SEED)
+    torch.cuda.manual_seed(SEED)
+    np.random.seed(SEED)
+    random.seed(SEED)
+
+
+MEAN = {"imagenet": [0.485, 0.456, 0.406], "clip": [0.48145466, 0.4578275, 0.40821073]}
+
+STD = {"imagenet": [0.229, 0.224, 0.225], "clip": [0.26862954, 0.26130258, 0.27577711]}
+
+
+def find_best_threshold(y_true, y_pred):
+    "We assume first half is real 0, and the second half is fake 1"
+
+    N = y_true.shape[0]
+
+    if y_pred[0 : N // 2].max() <= y_pred[N // 2 : N].min():  # perfectly separable case
+        return (y_pred[0 : N // 2].max() + y_pred[N // 2 : N].min()) / 2
+
+    best_acc = 0
+    best_thres = 0
+    # もし本当のラベルの最大予測値が偽のラベルの最小予測値以下であれば（つまり，予測値が完全に分離可能であれば）
+    # この関数はこれら2つの値の平均をしきい値として返す．
+    # 予測が完全に分離可能でない場合，関数は best_acc （最高の精度）と best_thres （最高のしきい値）を0に初期化する．
+    for thres in y_pred:
+        temp = deepcopy(y_pred)
+        temp[temp >= thres] = 1
+        temp[temp < thres] = 0
+
+        acc = (temp == y_true).sum() / N
+        if acc >= best_acc:
+            best_thres = thres
+            best_acc = acc
+
+    return best_thres
+
+
+def png2jpg(img, quality):
+    out = BytesIO()
+    img.save(out, format="jpeg", quality=quality)  # ranging from 0-95, 75 is default
+    img = Image.open(out)
+    # load from memory before ByteIO closes
+    img = np.array(img)
+    out.close()
+    return Image.fromarray(img)
+
+
+def gaussian_blur(img, sigma):
+    img = np.array(img)
+
+    gaussian_filter(img[:, :, 0], output=img[:, :, 0], sigma=sigma)
+    gaussian_filter(img[:, :, 1], output=img[:, :, 1], sigma=sigma)
+    gaussian_filter(img[:, :, 2], output=img[:, :, 2], sigma=sigma)
+
+    return Image.fromarray(img)
+
+
+def calculate_acc(y_true, y_pred, thres):
+    r_acc = accuracy_score(y_true[y_true == 0], y_pred[y_true == 0] > thres)
+    f_acc = accuracy_score(y_true[y_true == 1], y_pred[y_true == 1] > thres)
+    acc = accuracy_score(y_true, y_pred > thres)
+    # r_acc:0である真のラベルの予測精度 f_acc:1である真のラベルの予測精度　# acc:全体の予測精度
+    return r_acc, f_acc, acc
+
+
+def validate(model, loader, find_thres=False):
+
+    with torch.no_grad():
+        y_true, y_pred = [], []
+        print("Length of dataset: %d" % (len(loader)))
+        device = torch.device("cuda:0")
+        for img, label in loader:
+            in_tens = img.to(device)
+            y_pred.extend(model(in_tens).sigmoid().flatten().tolist())
+            y_true.extend(label.flatten().tolist())
+
+    y_true, y_pred = np.array(y_true), np.array(y_pred)
+
+    # ================== save this if you want to plot the curves =========== #
+    # torch.save( torch.stack( [torch.tensor(y_true), torch.tensor(y_pred)] ),  'baseline_predication_for_pr_roc_curve.pth' )
+    # exit()
+    # =================================================================== #
+
+    # Get AP
+    ap = average_precision_score(y_true, y_pred)
+
+    # Acc based on 0.5
+    # r_acc0:0である真のラベルの予測精度 f_acc0:1である真のラベルの予測精度　# acc0:全体の予測精度
+    r_acc0, f_acc0, acc0 = calculate_acc(y_true, y_pred, 0.5)
+    if not find_thres:
+        return ap, r_acc0, f_acc0, acc0
+
+    # Acc based on the best thres
+    best_thres = find_best_threshold(y_true, y_pred)
+    r_acc1, f_acc1, acc1 = calculate_acc(y_true, y_pred, best_thres)
+
+    return ap, r_acc0, f_acc0, acc0, r_acc1, f_acc1, acc1, best_thres
+
+
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = #
+
+
+def recursively_read(rootdir, must_contain, exts=["png", "jpg", "JPEG", "jpeg", "bmp"]):
+    print(f"rootdir: {rootdir}")
+    out = []
+    for r, d, f in os.walk(rootdir):
+        for file in f:
+            if (file.split(".")[1] in exts) and (must_contain in os.path.join(r, file)):
+                out.append(os.path.join(r, file))
+    return out
+
+
+def get_list(path, must_contain=""):
+    if ".pickle" in path:
+        with open(path, "rb") as f:
+            image_list = pickle.load(f)
+        image_list = [item for item in image_list if must_contain in item]
+    else:
+        image_list = recursively_read(path, must_contain)
+    return image_list
+
+
+class RealFakeUmapDataset(Dataset):
+    def __init__(
+        self,
+        real_path,
+        fake_path,
+        data_mode,
+        max_sample,
+        key,
+        arch,
+        jpeg_quality=None,
+        gaussian_sigma=None,
+    ):
+        assert data_mode in ["wang2020", "ours"]
+        self.jpeg_quality = jpeg_quality
+        self.gaussian_sigma = gaussian_sigma
+
+        # = = = = = = data path = = = = = = = = = #
+        if isinstance(real_path, str) and isinstance(fake_path, str):
+            real_list, fake_list = self.read_path(
+                real_path, fake_path, data_mode, max_sample
+            )
+        else:
+            real_list = []
+            fake_list = []
+            for real_p, fake_p in zip(real_path, fake_path):
+                real_l, fake_l = self.read_path(real_p, fake_p, data_mode, max_sample)
+                real_list += real_l
+                fake_list += fake_l
+
+        print(f"real_list: {len(real_list)}")
+        print(f"fake_list: {len(fake_list)}")
+        self.total_list = real_list + fake_list
+
+        # = = = = = =  label = = = = = = = = = #
+        self.labels_dict = {}
+        # GANのラベルを1に設定
+        if key in ["progan", "cyclegan", "biggan", "gaugan", "stargan", "ffhq"]:
+            for i in real_list:
+                self.labels_dict[i] = 0
+            for i in fake_list:
+                self.labels_dict[i] = 1
+        # DMのラベルを2に設定
+        elif key in [
+            "guided",
+            "ldm_200",
+            "ldm_200_cfg",
+            "glide_100_27",
+            "glide_100_10",
+            "elsa",
+        ]:
+            for i in real_list:
+                self.labels_dict[i] = 0
+            for i in fake_list:
+                self.labels_dict[i] = 2
+        else:
+            raise ValueError()
+
+        stat_from = "imagenet" if arch.lower().startswith("imagenet") else "clip"
+        self.transform = transforms.Compose(
+            [
+                transforms.CenterCrop(224),
+                transforms.ToTensor(),
+                transforms.Normalize(mean=MEAN[stat_from], std=STD[stat_from]),
+            ]
+        )
+
+    def read_path(self, real_path, fake_path, data_mode, max_sample):
+
+        # 'wang2020'：0_realと1_fakeを含むディレクトリ
+        # 　'ours'：それ以外のディレクトリ
+        if data_mode == "wang2020":
+            real_list = get_list(real_path, must_contain="0_real")
+            fake_list = get_list(fake_path, must_contain="1_fake")
+        else:
+            real_list = get_list(real_path)
+            fake_list = get_list(fake_path)
+
+        if max_sample is not None:
+            if (max_sample > len(real_list)) or (max_sample > len(fake_list)):
+                max_sample = 100
+                print("not enough images, max_sample falling to 100")
+            random.shuffle(real_list)
+            random.shuffle(fake_list)
+            real_list = real_list[0:max_sample]
+            fake_list = fake_list[0:max_sample]
+
+        assert len(real_list) == len(fake_list)
+
+        return real_list, fake_list
+
+    def __len__(self):
+        return len(self.total_list)
+
+    def __getitem__(self, idx):
+
+        img_path = self.total_list[idx]
+
+        label = self.labels_dict[img_path]
+        # print(label)
+        img = Image.open(img_path).convert("RGB")
+
+        if self.gaussian_sigma is not None:
+            img = gaussian_blur(img, self.gaussian_sigma)
+        if self.jpeg_quality is not None:
+            img = png2jpg(img, self.jpeg_quality)
+
+        img = self.transform(img)
+        return img, label


### PR DESCRIPTION
# Changes
UMAPで複数のデータセットを入れて、GANとDMとREALの区別をできるようにするモードを追加した。
--gan_dmを使用してください。

また、ファイル名を引数で指定できるようにしました。

--file_nameで指定してください。

# How to Test

```
poetry run python visualization/extract_features.py --gan_dm --file_name mmmmm.npz
```
```
poetry run python visualization/visualize_plot.py -i outputs/mmmmm.npz
```

これでウェブサイト上にUMAPの可視化結果が出ればOKです

# Note for reviewers
可視化ができない場合はポートが合っているか確認してください
また、今回は使用できるデータセットが限定されています。必要に応じて増やすかもしれません。

