### PR TITLE
Feat/add attention map synclr stablerep

### DIFF
--- a/models/stablerep_models.py
+++ b/models/stablerep_models.py
@@ -24,3 +24,16 @@ class StableRepModel(nn.Module):
         if return_feature:
             return features
         return self.fc(features)
+
+    def get_attention_weights_dict(self, x):
+        return self.model.get_all_layers_attention_weights(x)
+
+
+if __name__ == "__main__":
+
+    model = StableRepModel(name="a").cuda().eval()
+    attention_weights = model.get_attention_weights_dict(
+        torch.rand(1, 3, 224, 224).cuda()
+    )
+    for layer, weights in attention_weights.items():
+        print(f"{layer}: {weights.shape}")

--- a/models/synclr/attention.py
+++ b/models/synclr/attention.py
@@ -1,0 +1,50 @@
+import torch
+import torch.nn as nn
+import torch.utils.checkpoint
+
+
+class Attention(nn.Module):
+
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int = 8,
+        qkv_bias: bool = False,
+        qk_norm: bool = False,
+        attn_drop: float = 0.0,
+        proj_drop: float = 0.0,
+        norm_layer: nn.Module = nn.LayerNorm,
+    ) -> None:
+        super().__init__()
+        assert dim % num_heads == 0, "dim should be divisible by num_heads"
+        self.num_heads = num_heads
+        self.head_dim = dim // num_heads
+        self.scale = self.head_dim**-0.5
+
+        self.qkv = nn.Linear(dim, dim * 3, bias=qkv_bias)
+        self.q_norm = norm_layer(self.head_dim) if qk_norm else nn.Identity()
+        self.k_norm = norm_layer(self.head_dim) if qk_norm else nn.Identity()
+        self.attn_drop = nn.Dropout(attn_drop)
+        self.proj = nn.Linear(dim, dim)
+        self.proj_drop = nn.Dropout(proj_drop)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        B, N, C = x.shape
+        qkv = (
+            self.qkv(x)
+            .reshape(B, N, 3, self.num_heads, self.head_dim)
+            .permute(2, 0, 3, 1, 4)
+        )
+        q, k, v = qkv.unbind(0)
+        q, k = self.q_norm(q), self.k_norm(k)
+
+        q = q * self.scale
+        attn = q @ k.transpose(-2, -1)
+        attn = attn.softmax(dim=-1)
+        attn = self.attn_drop(attn)
+        x = attn @ v
+
+        x = x.transpose(1, 2).reshape(B, N, C)
+        x = self.proj(x)
+        x = self.proj_drop(x)
+        return x, attn

--- a/models/synclr_models.py
+++ b/models/synclr_models.py
@@ -23,3 +23,16 @@ class SynCLRModel(nn.Module):
         if return_feature:
             return features
         return self.fc(features)
+
+    def get_attention_weights_dict(self, x):
+        return self.model.get_all_layers_attention_weights(x)
+
+
+if __name__ == "__main__":
+
+    model = SynCLRModel(name="a").cuda().eval()
+    attention_weights = model.get_attention_weights_dict(
+        torch.rand(1, 3, 224, 224).cuda()
+    )
+    for layer, weights in attention_weights.items():
+        print(f"{layer}: {weights.shape}")


### PR DESCRIPTION
# Changes
SynCLRとStableRepでアテンション可視化コードを追加

そのために`models/synclr/attention.py`を追加し、`models/synclr/vision_transformer_synclr.py`で必要な変更を加えた

また、clip_attention_map.pyから名前をattention_map.pyに変更しました。
保存先のフォルダがない場合は自動でつくるようにしました。

# How to Test

[こちらの写真](https://github.com/Hina39/UniversalFakeDetect/assets/61688218/707393d4-a461-419e-8a56-1a58d07b6066)をdatasets/test/progan/bird/0_real/06154.pngに置き、以下のコードを実行する
```
poetry run python visualization/attention_map.py --arch SynCLR:ViT-B/16
```

# Note for reviewers
頑張りました。